### PR TITLE
bug fix segfault; fix memory leaks

### DIFF
--- a/src/aho_trie.c
+++ b/src/aho_trie.c
@@ -108,6 +108,8 @@ bool __aho_connect_link(struct aho_trie_node* p, struct aho_trie_node* q)
     }
 
     pf = p->failure_link;
+    if( pf == NULL )
+        return true;
     for (i=0; i < pf->child_count; i++)
     {
         /* check child node of failure link(p) */
@@ -218,6 +220,8 @@ bool __aho_find_trie_node(struct aho_trie_node** restrict start, const unsigned 
     int i = 0;
 
     search_node = *start;
+    if ( search_node == NULL)
+        return false;
     for (i = 0; i < search_node->child_count; i++)
     {
         if (search_node->child_list[i]->text == text)
@@ -239,7 +243,8 @@ struct aho_text_t* aho_find_trie_node(struct aho_trie_node** restrict start, con
         /* not found!
          * when root node stop
          */
-        if( (*start)->parent == NULL)
+
+        if( *start == NULL || (*start)->parent == NULL)
         {
             return NULL;
         }

--- a/src/aho_trie.c
+++ b/src/aho_trie.c
@@ -73,6 +73,7 @@ bool aho_add_trie_node(struct aho_trie * restrict t, struct aho_text_t * restric
             struct aho_trie_node* child_node = NULL;
 
             travasal_node->child_list[travasal_node->child_count] =
+
                          (struct aho_trie_node*) malloc(sizeof(struct aho_trie_node));
 
             child_node = travasal_node->child_list[travasal_node->child_count];
@@ -101,15 +102,13 @@ bool __aho_connect_link(struct aho_trie_node* p, struct aho_trie_node* q)
     int i = 0;
 
     /* is root node */
-    if (p->parent == NULL)
+    if (p->failure_link == NULL || p->parent == NULL)
     {
         q->failure_link = p;
         return true;
     }
 
     pf = p->failure_link;
-    if( pf == NULL )
-        return true;
     for (i=0; i < pf->child_count; i++)
     {
         /* check child node of failure link(p) */

--- a/src/ahocorasick.c
+++ b/src/ahocorasick.c
@@ -34,7 +34,7 @@ int aho_add_match_text(struct ahocorasick * restrict aho, const char* text, unsi
         goto lack_free_mem;
 
     a_text->id = aho->accumulate_text_id++;
-    memcpy(a_text->text, text, len);
+    memcpy(a_text->text, text, len+1);
     a_text->len = len;
     a_text->prev = NULL;
     a_text->next = NULL;
@@ -139,7 +139,7 @@ unsigned int aho_findtext(struct ahocorasick * restrict aho, const char* data, u
     {
         struct aho_match_t match;
         struct aho_text_t* result;
-
+        
         result = aho_find_trie_node(&travasal_node, data[i]);
         if (result == NULL)
         {

--- a/src/ahocorasick.c
+++ b/src/ahocorasick.c
@@ -73,15 +73,18 @@ bool aho_del_match_text(struct ahocorasick * restrict aho, const int id)
             if (iter == aho->text_list_head)
             {
                 aho->text_list_head = iter->next;
+                free(iter->text);
             }
             else if (iter == aho->text_list_tail)
             {
                 aho->text_list_tail = iter->prev;
+                free(iter->text);
             }
             else
             {
                 iter->prev->next = iter->next;
                 iter->next->prev = iter->prev;
+                free(iter->text);
             }
             free(iter);
             aho->text_list_len--;


### PR DESCRIPTION
Addressed bug in https://github.com/morenice/ahocorasick/issues/2; the issue was caused by the final suffix link for the dictionary entry not being set correctly.

Also, cleaned up memory leaks.