### PR TITLE
Return all texts for a matched trie node

### DIFF
--- a/include/aho_trie.h
+++ b/include/aho_trie.h
@@ -32,7 +32,7 @@ bool aho_add_trie_node(struct aho_trie * restrict t, struct aho_text_t * restric
 void aho_connect_link(struct aho_trie * restrict t);
 void aho_clean_trie_node(struct aho_trie * restrict t);
 
-struct aho_text_t* aho_find_trie_node(struct aho_trie_node** restrict start, const unsigned char text);
+struct aho_trie_node* aho_find_trie_node(struct aho_trie_node** restrict start, const unsigned char text);
 
 void aho_print_trie(struct aho_trie * restrict t);
 

--- a/src/aho_trie.c
+++ b/src/aho_trie.c
@@ -235,7 +235,7 @@ bool __aho_find_trie_node(struct aho_trie_node** restrict start, const unsigned 
     return false;
 }
 
-struct aho_text_t* aho_find_trie_node(struct aho_trie_node** restrict start, const unsigned char text)
+struct aho_trie_node* aho_find_trie_node(struct aho_trie_node** restrict start, const unsigned char text)
 {
     while (__aho_find_trie_node(start, text) == false)
     {
@@ -253,20 +253,7 @@ struct aho_text_t* aho_find_trie_node(struct aho_trie_node** restrict start, con
     }
 
     /* found node... */
-    /* match case1: find text end! */
-    if ((*start)->text_end)
-    {
-        return (*start)->output_text;
-    }
-
-    /* match case2: exist output_link */
-    if ((*start)->output_link)
-    {
-        return (*start)->output_link->output_text;
-    }
-
-    /* keep going */
-    return NULL;
+    return *start;
 }
 
 void aho_print_trie(struct aho_trie * restrict t)

--- a/src/ahocorasick.c
+++ b/src/ahocorasick.c
@@ -127,6 +127,30 @@ void aho_clear_trie(struct ahocorasick * restrict aho)
     aho_destroy_trie(&aho->trie);
 }
 
+unsigned int aho_trie_node_recursive_callback(struct ahocorasick * restrict aho, struct aho_trie_node * restrict node, int offset)
+{
+	int retval = 0;
+	if (node) {
+		if (node->text_end) {
+			retval++;
+			if (aho->callback_match) {
+				//~ result->output_text->text
+				struct aho_match_t match;
+				match.id = node->output_text->id;
+				match.len = node->output_text->len;
+				match.pos = offset - node->output_text->len + 1;
+				aho->callback_match(aho->callback_arg, &match);
+			}
+		}
+
+		/* match case2: exist output_link */
+		if (node->output_link) {
+			retval += aho_trie_node_recursive_callback(aho, node->output_link, offset);
+		}
+	}
+	return retval;
+}
+
 unsigned int aho_findtext(struct ahocorasick * restrict aho, const char* data, unsigned long long data_len)
 {
     int i = 0;
@@ -137,28 +161,10 @@ unsigned int aho_findtext(struct ahocorasick * restrict aho, const char* data, u
 
     for (i = 0; i < data_len; i++)
     {
-        struct aho_match_t match;
-        struct aho_text_t* result;
-        
-        result = aho_find_trie_node(&travasal_node, data[i]);
-        if (result == NULL)
+        struct aho_trie_node* result = aho_find_trie_node(&travasal_node, data[i]);
+        if (result)
         {
-            continue;
-        }
-
-        match.id = result->id;
-        match.len = result->len;
-
-        match.pos = i - result->len + 1;
-        if (result->len == 1)
-        {
-            match.pos = i;
-        }
-
-        match_count++;
-        if (aho->callback_match)
-        {
-            aho->callback_match(aho->callback_arg, &match);
+			match_count += aho_trie_node_recursive_callback(aho, result, i);
         }
     }
 


### PR DESCRIPTION
The aho_find_trie_node() can currently only return one text. A trie node
can contain multiple matches and should return multiple texts.
The function is changed so it now returns the matched node (which mostly is the
traversal node). A new function will recursively process this node
and count all texts and perform a callback for each text.

for example:
https://www.youtube.com/watch?v=qPyhPXPl3T4
(see 7:00 minute mark)