### PR TITLE
fixed bug; few memory allocation

### DIFF
--- a/src/ahocorasick.c
+++ b/src/ahocorasick.c
@@ -29,7 +29,7 @@ int aho_add_match_text(struct ahocorasick * restrict aho, const char* text, unsi
     if (!a_text)
         goto lack_free_mem;
 
-    a_text->text = (char*) malloc(sizeof(char)*len);
+    a_text->text = (char*) malloc(sizeof(char)*len+1);
     if (!a_text->text)
         goto lack_free_mem;
 


### PR DESCRIPTION
fix https://github.com/morenice/ahocorasick/issues/10

https://github.com/morenice/ahocorasick/blob/9dad855b3eb8a4585c90308ba71c62652e39a3a1/src/ahocorasick.c#L37
`a_text->text` memory size is less than ` len+1`.
So, extend malloc size.

plz review my PR. thank you!.